### PR TITLE
learn: bootstrap project Expert (memory) from main@0a7e1ae

### DIFF
--- a/.claude/skills/expert/SKILL.md
+++ b/.claude/skills/expert/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: expert
+description: LearnerMax project Expert — the codebase's long-term memory. Architecture (Next.js↔Express/Lambda/DynamoDB↔Cognito), how features are verified here, core files, DO/DON'T patterns, hard invariants, and the steps to add a feature. Consult before non-trivial work: adding a feature, choosing where code lives, debugging, or deciding how to verify a change. Triggers - expert, project expert, learnermax architecture, where does this code go, how is this verified, project invariants, how to add a feature (project)
+---
+
+# LearnerMax Expert
+
+This project's **long-term memory**, pulled on demand. It reflects what is
+committed to `main` (not what is planned — for intent, read the PRD/spec). Updated
+only by `/learn` after a merge. Consult the relevant reference before non-trivial work.
+
+## Quick reference
+
+| You're about to… | Read | Mode |
+|---|---|---|
+| understand the system shape, layers, boundaries, auth + event flows | `references/architecture.md` | Expert |
+| find the key files / where a concern lives | `references/core-files.md` | Expert |
+| decide how to test/verify a change; run the app locally | `references/verification.md` | Expert |
+| write code in a way that fits (soft DO/DON'T) | `references/patterns.md` | Expert |
+| check a hard rule before you break it (lint-enforced) | `references/invariants.md` | Expert |
+| add a new feature end-to-end (the steps) | `references/procedural.md` | Expert |
+| see what `/learn` changed and why | `references/changelog.md` | Expert |
+
+## The one-paragraph orientation
+
+LearnerMax is an open-source course app. A **Next.js 15 App Router** frontend
+(Vercel) talks over HTTP to an **Express API running in AWS Lambda** (via the Lambda
+Web Adapter) backed by a **single-table DynamoDB** design. Auth is **AWS Cognito**:
+the frontend uses NextAuth (JWT session) and sends the Cognito **ID token** as a
+Bearer; API Gateway's Cognito authorizer validates it before the request reaches
+Express. Sign-up fans out event-driven: Cognito **PostConfirmation → SNS → Student
+Onboarding Lambda → DynamoDB**. Backend code is organized as **feature vertical
+slices** (`routes → service → repository`); the frontend reaches the backend four
+ways (server actions, server fetchers, BFF route handlers, client SWR) and **never
+touches the database directly**. See `references/architecture.md` for the full shape.

--- a/.claude/skills/expert/references/architecture.md
+++ b/.claude/skills/expert/references/architecture.md
@@ -1,0 +1,94 @@
+# Architecture — the shape and the why
+
+Distilled from committed code + `architecture-compact.md` / `architecture.md` at repo
+root (read those for the full diagrams). This shard is the map; cite `core-files.md`
+for exact paths.
+
+## System shape
+
+```
+Browser ──HTTPS──> Next.js 15 App Router (Vercel) ──HTTP (Bearer id_token)──>
+   API Gateway (Cognito authorizer validates JWT) ──> Lambda Web Adapter ──>
+   Express.js (Node 22, arm64 Lambda) ──> DynamoDB (single-table: EducationTable)
+
+Auth: AWS Cognito User Pool (email/password + Google OAuth federation).
+Event-driven sign-up: Cognito PostConfirmation Lambda ──> SNS topic ──>
+   Student Onboarding Lambda ──> DynamoDB (with a DLQ on failure).
+```
+
+Two independently deployed packages — **frontend (Vercel)** and **backend (AWS SAM)**
+— whose only contract is the HTTP API. They never import each other's source
+(`invariants.md` INV: `frontend-no-backend-import`).
+
+## Backend layering — feature vertical slices
+
+There is **no global `routes/`/`services/`/`models/`**. Each feature owns its slice
+under `backend/src/features/<feature>/`:
+
+```
+<feature>.routes.ts      HTTP layer: auth check, input validation, status codes
+   └─ <feature>.service.ts    business logic (some simple features skip this)
+        └─ <feature>.repository.ts   ALL DynamoDB I/O via the shared docClient
+<feature>.types.ts / .entity.ts   shapes
+```
+
+Dependency direction is strictly downward (routes → service → repository); lower
+layers never import upward. Cross-cutting concerns live in `backend/src/lib/`
+(logger, metrics, dynamodb client, auth-utils, cloudfront/sns helpers). The Express
+app is composed in a single root, `backend/src/app.ts`, which mounts every feature
+router under `/api/*` — the one place to see the full URL surface.
+
+**Separate from Express:** event-driven Lambda handlers in `backend/src/lambdas/`
+(`post-confirmation.ts`, `student-onboarding.ts`) are their own entrypoints, not
+routes. `student-onboarding.ts` builds its own DocumentClient (it's a different
+Lambda), which is the one sanctioned exception to "DynamoDB only via repositories."
+
+## Data model — single-table DynamoDB
+
+One table, `EducationTable` (env `EDUCATION_TABLE_NAME`; defined in `backend/template.yaml`):
+- Primary key `PK` (HASH) + `SK` (RANGE); GSI `GSI1` (`GSI1PK`/`GSI1SK`); GSI `email-index` (HASH `email`).
+- Item shapes by `entityType`, e.g. user = `PK=USER#<id>, SK=METADATA`; enrollment =
+  `PK=USER#<id>, SK=COURSE#<courseId>`, mirrored on `GSI1` for the inverse lookup.
+- Repositories build keys, use `ConditionExpression: attribute_not_exists(PK)` to
+  prevent duplicate writes, and **strip internal keys** (`PK,SK,GSI1PK,GSI1SK,entityType`)
+  before returning domain objects.
+
+## Auth — two schemes, one identity
+
+- **Frontend protection:** NextAuth (`strategy: 'jwt'`, httpOnly cookie). The
+  `authorized` callback + `frontend/proxy.ts` (Next.js middleware) gate routes; the
+  JWT carries the Cognito access/id/refresh tokens, refreshed on expiry.
+- **Backend protection:** API Gateway's **Cognito authorizer** validates the JWT
+  natively and injects claims into the request context. Express reads the user via
+  `getUserIdFromContext(req)` (parses the `x-amzn-request-context` header → Cognito
+  `sub`) and returns 401 on null. Public routes are explicitly `Authorizer: NONE`
+  in `template.yaml` (currently the two SSG course reads).
+- **The token on the wire is the Cognito ID token** (not the access token) — API
+  Gateway validates the id_token; the frontend sources it server-side via
+  `getAuthToken()` and never exposes it to client components.
+
+## Frontend — four ways to reach the backend
+
+All run server-side or proxy through the server; **the browser never holds the
+id_token and the frontend never touches the DB**:
+1. **Server actions** (`frontend/app/actions/*`, `'use server'`) — mutations.
+2. **Server fetchers** (`frontend/lib/data/*`) — reads for server components, with
+   Next.js `'use cache'` tags where appropriate.
+3. **BFF route handlers** (`frontend/app/api/*`) — let client SWR reach the backend
+   while the id_token stays server-side.
+4. **Client SWR hooks** (`frontend/hooks/*` via `frontend/lib/fetchers.ts`) — call
+   the local `/api/*` BFF with `credentials: 'include'`, never the backend directly.
+
+The backend base URL is `NEXT_PUBLIC_API_URL` (validated accessor `getApiBaseUrl()`
+in `frontend/lib/env.ts`). CloudFront signed cookies for video access are minted in
+`proxy.ts` against the backend's `video-access` endpoint.
+
+## Why this shape
+
+- **Lambda Web Adapter** lets a normal Express app run serverless without rewriting
+  to per-route handlers — familiar code, serverless ops.
+- **Single-table design** serves the known access patterns (user, enrollments by
+  user, enrollment by course) with two GSIs instead of multiple tables/joins.
+- **Event-driven onboarding** decouples sign-up latency from the DynamoDB write and
+  gives a retry/DLQ path, so a transient write failure never blocks account creation.
+- **BFF pattern** keeps the Cognito id_token off the client entirely.

--- a/.claude/skills/expert/references/changelog.md
+++ b/.claude/skills/expert/references/changelog.md
@@ -1,0 +1,35 @@
+# Changelog — Expert provenance
+
+What `/learn` changed, when, why, and the consensus behind it. Newest first.
+
+## 2026-06-03 — Bootstrap (`/learn --rebuild`), base `main@0a7e1ae`
+
+**Mode:** bootstrap (no prior Expert). Memory seeded from a full scan of committed
+code on `main`, not a diff.
+
+**Consensus:** four parallel codebase analyzers (backend, frontend, verification,
+invariants) independently scanned the tree; agreement across agents on the same rules
+— each invariant cross-confirmed with a 0-violation count against current `main` —
+served as the consensus gate for this from-scratch seed. Every promoted lint was run
+against `main` and passes (the must-pass-current-main discriminator).
+
+**Surfaces written:**
+- `SKILL.md` + all reference shards: `architecture.md`, `core-files.md`,
+  `verification.md`, `patterns.md`, `invariants.md`, `procedural.md`.
+- **Invariants → lints (4 enforced).** `no-frontend-db.sh` (pre-existing, from
+  `/harness-init`) + 3 new: `no-console-backend.sh`, `frontend-no-backend-import.sh`,
+  `server-actions-use-server.sh`. All under `scripts/lints/`, auto-run by
+  `local-checks.sh §5`. Each is a 1-line-grep, structural/security rule, 0 violations.
+- **Invariants → prose (6 candidates).** ES-modules-only, DynamoDB-only-via-repository,
+  backend `.js`-import-extension, no-`as any`-in-backend, client-only-`NEXT_PUBLIC_*`-env,
+  all-routers-registered-in-app.ts — recorded with check commands; promote to lints on
+  recurrence or by human decision.
+
+**Not changed:** root `AGENTS.md` left as-is (its Expert pointer now resolves since
+`.claude/skills/expert/` exists; its remaining `check-agents-md.sh` warnings are the
+known slash-command/`<f>`-token false positives, so the freshness lint stays advisory
+in `local-checks.sh §6` — promote to blocking once those are reconciled).
+
+**Note on scope:** this is *snapshot* discovery (the code as it is, one time). Future
+`/learn` runs do *stream* discovery over merged diffs and may promote the prose
+candidates above as they recur.

--- a/.claude/skills/expert/references/core-files.md
+++ b/.claude/skills/expert/references/core-files.md
@@ -1,0 +1,45 @@
+# Core files & abstractions
+
+Paths relative to repo root. The map; for the *why* see `architecture.md`.
+
+## Backend (`backend/`) — Express on Lambda + DynamoDB
+
+| File | Role |
+|---|---|
+| `src/app.ts` | Express composition root — mounts every feature router under `/api/*`. The full URL surface. Listens on :8080 (skipped when `NODE_ENV==='test'`). |
+| `src/run.sh` | Lambda Web Adapter entry (`node dist/app.js`). |
+| `template.yaml` | SAM infra — API Gateway + Cognito authorizer, DynamoDB `EducationTable` (PK/SK, GSI1, email-index), the two trigger Lambdas, SNS topic + DLQ, public-vs-protected route config. |
+| `src/lib/dynamodb.ts` | The shared `docClient` (`DynamoDBDocumentClient`). The ONE DB client for the Express app. |
+| `src/lib/auth-utils.ts` | `getUserIdFromContext(req)` / `getUserClaimsFromContext(req)` — parse Cognito `sub`/claims from the `x-amzn-request-context` header. |
+| `src/lib/logger.ts` / `src/lib/metrics.ts` | `createLogger()` / `createMetrics()` — Powertools structured logs + EMF metrics. |
+| `src/lib/cloudfront-signer.ts`, `cloudfront-cookies.ts`, `sns.ts` | signed-URL/cookie + SNS helpers. |
+| `src/middleware/observability.middleware.ts` | wraps `res.end` to log + emit latency/4xx/5xx metrics per request. |
+| `src/features/<f>/<f>.routes.ts` `.service.ts` `.repository.ts` `.types.ts` | the per-feature vertical slice. Features: `students`, `enrollment` (+ `strategies/`), `courses`, `lessons` (+ `services/video-url-service.ts`), `progress`, `meetups`, `feedback`, `video-access`. |
+| `src/lambdas/post-confirmation.ts` | Cognito PostConfirmation trigger → publishes onboarding msg to SNS (never throws — won't block sign-up). |
+| `src/lambdas/student-onboarding.ts` | SNS-triggered writer → student item to DynamoDB, `attribute_not_exists(PK)` for idempotency; re-throws non-duplicate errors → SNS retry → DLQ. Builds its own docClient (sanctioned exception). |
+
+## Frontend (`frontend/`) — Next.js 15 App Router
+
+| File | Role |
+|---|---|
+| `app/layout.tsx` | only layout — `SessionProvider`, `SWRProvider`, fonts, Analytics. |
+| `app/page.tsx`, `app/dashboard/page.tsx`, `app/course/[courseId]/page.tsx`, `app/signin`, `app/enroll`, `app/verify-email` | the page routes (dashboard + course are auth-guarded). |
+| `proxy.ts` | Next.js middleware (named `proxy` in Next 16+). Mints CloudFront signed cookies for `/course/*` via the backend `video-access` endpoint, then falls through to NextAuth `auth()` route protection. |
+| `auth.config.ts` + `lib/auth.ts` | NextAuth: JWT session, `authorized` route-protection callback, token refresh; providers = Cognito OIDC (Google federation) + Credentials (email/password via `lib/cognito-auth.ts`). |
+| `lib/cognito.ts`, `lib/cognito-auth.ts` | direct Cognito SDK calls (sign-up/confirm/resend; password auth). The only `@aws-sdk/*` in the frontend (Cognito, not DB). |
+| `app/actions/*.ts` (`'use server'`) | mutations: `auth`, `enrollments`, `progress`, `students`, `meetups`, `feedback`. `auth.ts:getAuthToken()` is the single server-side id_token accessor. |
+| `lib/data/*.ts` | server fetchers for server components (with `'use cache'` tags). |
+| `app/api/*/route.ts` | BFF route handlers — let client SWR reach the backend with the id_token kept server-side. |
+| `lib/fetchers.ts` + `hooks/use*.ts` | client SWR layer — call the local `/api/*` BFF only. |
+| `lib/env.ts` | `getApiBaseUrl()` — validated `NEXT_PUBLIC_API_URL` accessor (throws if unset). |
+| `components/ui/*` | shadcn primitives (new-york style, `components.json`); `components/<feature>/*` for domain components. |
+
+## E2E (`e2e/`) & root scripts
+
+| File | Role |
+|---|---|
+| `e2e/playwright.config.ts` | two projects: `api` (REST, no browser) + `ui` (Chrome, `BASE_URL`). Runs against a deployed Vercel **preview**, not a local server. |
+| `e2e/.env` | `BASE_URL`, `API_URL`, `API_KEY`, `VERCEL_AUTOMATION_BYPASS_SECRET` — written by the deploy scripts. |
+| `scripts/deploy-preview-{backend,frontend}.sh` | SAM `--config-env preview` / Vercel deploy; write endpoints back into `e2e/.env`. |
+| `scripts/{start,stop}-{sam,vercel}-logs.sh` | tail deploy logs into `scripts/.{sam,vercel}-logs.log` (the agent "signal" log files). |
+| `scripts/local-checks.sh` + `scripts/lints/*.sh` | the deterministic gate (see `verification.md`). |

--- a/.claude/skills/expert/references/invariants.md
+++ b/.claude/skills/expert/references/invariants.md
@@ -1,0 +1,48 @@
+# Invariants — hard rules the codebase upholds
+
+Hard = mechanically checkable, pass/fail, no judgment (contrast `patterns.md`, which
+is soft taste). Each was verified to hold with **0 violations** at bootstrap. The
+highest-value ones are promoted to enforced lints in `scripts/lints/` (wired into
+`scripts/local-checks.sh §5`, which auto-runs the whole dir). The rest are recorded
+as prose with a check command and **promoted to a lint on recurrence** (the discipline:
+one occurrence is a pattern; repetition across merges is an enforceable invariant).
+
+## Enforced (lint exists today)
+
+| Rule | Why | Lint |
+|---|---|---|
+| **Frontend never imports a DynamoDB/AWS DB client.** All persistence goes through the backend HTTP API. | UI layer must not couple to the data store or bypass backend authz/validation. | `scripts/lints/no-frontend-db.sh` |
+| **No `console.*` in `backend/src` app code** — use `createLogger()`. | Lambda/CloudWatch consume structured JSON; `console` breaks log queries + metric correlation. | `scripts/lints/no-console-backend.sh` |
+| **`frontend/` never imports from `backend/`** (package boundary). | Two independent deployables (Vercel vs Lambda); the only contract is the HTTP API. A source import drags server/Node code into the client bundle. | `scripts/lints/frontend-no-backend-import.sh` |
+| **Every `frontend/app/actions/*.ts` starts with `'use server'`.** | Without it the bundler can pull server-only code (and id_token handling) into the client bundle — a secret/privilege boundary failure. | `scripts/lints/server-actions-use-server.sh` |
+
+## Recorded — prose now, candidate lint on recurrence
+
+Each holds at 0 violations today; the `check` is the grep a future `/learn` (or a
+human) promotes into `scripts/lints/` if the rule recurs or is deliberately enforced.
+
+- **ES modules only — no CommonJS `require()` in app code.** `backend` is `"type":
+  "module"`. WHY: a stray `require()` breaks the NodeNext resolver.
+  `check:` `grep -rnE '\brequire\(' backend/src frontend --include='*.ts' --include='*.tsx' --exclude-dir=node_modules | grep -vE '\.test\.|__tests__|__integration__'`
+- **All DynamoDB access funneled through `*.repository.ts`** (+ the shared
+  `backend/src/lib/dynamodb.ts`, + the standalone `src/lambdas/student-onboarding.ts`).
+  No `*.service.ts`/`*.routes.ts` imports the Dynamo SDK. WHY: one swappable storage
+  layer; marshalling config lives in one place. (Lint needs an allowlist for those 3 paths.)
+- **Backend relative imports carry the `.js` extension** (NodeNext ESM). WHY: required
+  at runtime under `"type": "module"`.
+  `check:` `grep -rnE "from '(\.\.?/)[^']*'" backend/src --include='*.ts' | grep -vE "\.(js|json)'"`
+- **No `as any` casts in `backend/src` app code.** WHY: preserves end-to-end type
+  safety. (Frontend has exactly one, `frontend/proxy.ts` `auth(request as any)`, so the
+  enforceable cut is backend-only.)
+- **Client components reference only `NEXT_PUBLIC_*` env (and `NODE_ENV`).** WHY: a
+  server-only env var in a client component is `undefined` at runtime or leaks a secret.
+- **Every backend feature router is registered in `backend/src/app.ts`.** WHY: one place
+  to see the full URL surface; no orphan route files. (Needs an `ls`-vs-`app.ts` diff, not a pure grep.)
+
+## The non-bypassable backbone (not lints — process invariants)
+
+- **`run-prd-test.sh` exit 0 is the definition of done.** No PR merges without it.
+- **Silencing a check is bypassing it.** New suppression directives (`@ts-ignore`,
+  `eslint-disable`, `as`/`!`), weakened configs, and added test skips are a human's
+  deliberate call on the branch — never an agent's. A green gate reached by silencing
+  is a regression in disguise.

--- a/.claude/skills/expert/references/patterns.md
+++ b/.claude/skills/expert/references/patterns.md
@@ -1,0 +1,48 @@
+# Patterns — soft DO/DON'T (judgment, not mechanical)
+
+These need taste; they're not lints (contrast `invariants.md`). Prefer them; deviate
+with reason.
+
+## Backend
+
+- **DO follow routes → service → repository per feature.** Routes own HTTP/auth/status;
+  services own business logic; repositories own all DynamoDB I/O. A simple feature may
+  skip the service (e.g. `feedback` routes call the repository directly) — fine when
+  there's no real logic, but add the service the moment logic appears.
+  Example: `backend/src/features/courses/{course.routes,course.service,course.repository}.ts`.
+- **DO authenticate in the route via `getUserIdFromContext(req)` and 401 on null.**
+  Uniform across all protected routes. Public routes must be explicitly `Authorizer: NONE`
+  in `template.yaml`. Example: `backend/src/features/progress/progress.routes.ts`.
+- **DO validate mutating request bodies with Zod (`schema.parse`) at the boundary**,
+  returning 400 on `ZodError`. This is the *preferred* direction — only `students` and
+  `feedback` routes do it today; `progress`/`enrollment` still use manual `typeof`
+  checks. New mutating routes should use Zod. Example: `feedback.routes.ts` (`createFeedbackSchema`).
+- **DO emit structured logs + metrics** — one `createLogger('<ModuleName>')` and
+  `createMetrics(...)` per module; never `console.*` (that's a lint).
+- **DON'T touch DynamoDB outside a `*.repository.ts`.** Keeps storage swappable and
+  marshalling centralized in `lib/dynamodb.ts`.
+- **DO use `ConditionExpression` for idempotent writes** (`attribute_not_exists(PK)`)
+  and **strip internal keys** (`PK,SK,GSI1PK,GSI1SK,entityType`) before returning a
+  domain object from a repository.
+
+## Frontend
+
+- **DO reach the backend the right way for the context:** server actions for mutations,
+  `lib/data/*` fetchers for server-component reads, BFF `app/api/*` handlers + SWR for
+  client reads. **Client code never calls the backend directly** — it goes through the
+  local `/api/*` BFF so the id_token stays server-side.
+- **DO source the id_token via `getAuthToken()`** (server-side) and attach it as
+  `Authorization: Bearer`. It's the Cognito **ID** token (what API Gateway validates),
+  not the access token.
+- **DO read the API base URL via `getApiBaseUrl()`** (`lib/env.ts`, throws if unset)
+  rather than raw `process.env.NEXT_PUBLIC_API_URL`, to fail fast on misconfig.
+- **DO keep server-only secrets/tokens out of client components** — non-`NEXT_PUBLIC_*`
+  env and session tokens live only in server actions / route handlers / server components.
+- **DO use shadcn primitives from `components/ui` + `cn()`**; put domain components under
+  `components/<feature>/` with co-located `__tests__/`.
+
+## Cross-cutting
+
+- **DO test at the cheapest layer that catches the bug.** Unit (mocked AWS / MSW) for
+  logic; integration only for real-infra behavior; e2e for the deployed surface.
+- **DON'T add a test skip or suppression to get green** — see `invariants.md` backbone.

--- a/.claude/skills/expert/references/procedural.md
+++ b/.claude/skills/expert/references/procedural.md
@@ -1,0 +1,59 @@
+# Procedural — how to add a feature here
+
+The concrete steps, grounded in the actual conventions. Adapt to scope.
+
+## A backend API feature (new resource under `/api/*`)
+
+1. **Create the slice** under `backend/src/features/<feature>/`:
+   - `<feature>.types.ts` — request/response + entity shapes.
+   - `<feature>.repository.ts` — DynamoDB I/O ONLY. Import `docClient` from
+     `../../lib/dynamodb.js`. Build `PK`/`SK` (+ `GSI1`) keys; strip internal keys
+     before returning; use `attribute_not_exists(PK)` for create-once writes.
+   - `<feature>.service.ts` — business logic (skip only if there's genuinely none).
+   - `<feature>.routes.ts` — `express.Router()`; in each protected handler call
+     `getUserIdFromContext(req)` → 401 on null; validate the body with a Zod schema
+     (`schema.parse`, 400 on `ZodError`); `try/catch` → `logger.error` + status JSON.
+     Create one `createLogger('<Feature>')` (+ `createMetrics` if you emit metrics).
+2. **Register the router** in `backend/src/app.ts` under `/api/<feature>` (the only
+   place routers are mounted).
+3. **Infra in `backend/template.yaml`** if needed: new access pattern → confirm the
+   GSIs cover it; new route's auth → it inherits the Cognito authorizer by default,
+   so add an explicit `Authorizer: NONE` entry only for a genuinely public route; new
+   IAM/env → add to the function definition.
+4. **Unit tests** in `__tests__/<...>.test.ts` with `aws-sdk-client-mock` for DynamoDB.
+   Integration test in `__integration__/*.integration.test.ts` only if real-infra
+   behavior matters (it runs against the preview table).
+
+## A frontend feature
+
+1. **Page/route** under `frontend/app/...`; guard protected pages with `auth()` +
+   `redirect('/signin?...')` (see `dashboard/page.tsx`).
+2. **Data access** — pick the right channel:
+   - mutation → server action in `frontend/app/actions/<x>.ts` (FIRST line `'use server'`),
+     get the token via `getAuthToken()`, `fetch` `${getApiBaseUrl()}/api/...` with Bearer.
+   - server-component read → `frontend/lib/data/<x>.ts` (cache-tag if cacheable).
+   - client read → BFF handler in `frontend/app/api/<x>/route.ts` + a client fetcher in
+     `lib/fetchers.ts` + an SWR hook in `hooks/use<X>.ts` (client calls the local `/api/*`,
+     never the backend directly).
+3. **Components** — domain components under `components/<feature>/`, built on
+   `components/ui` primitives + `cn()`; co-locate `__tests__/`.
+4. **Tests** — unit (jsdom, mocked next-auth/navigation); integration with MSW handlers
+   in `app/actions/__integration__/handlers.ts` for full-flow coverage.
+
+## Verifying before you open the PR
+
+- Run `./scripts/local-checks.sh` from repo root (lint, typecheck, fast unit, skip-detection,
+  custom lints). Fix with `./scripts/local-checks.sh fix` for the auto-fixable subset.
+- Make `./prds/<feature>/run-prd-test.sh` pass — that's the definition of done.
+- Run the app via `pnpm run dev:bg` (backend :8080, frontend :3000) and read `dev:logs`;
+  for deployed behavior, use the `deploy-preview-*` + `*-logs.sh` signal scripts.
+- Respect the invariants in `invariants.md` — the custom lints will catch the enforced ones.
+
+## Gotchas
+
+- Backend is ESM (`"type": "module"`): **relative imports need the `.js` extension**.
+- The token on the wire is the Cognito **ID** token, not the access token.
+- Integration tests need `backend/.env.integration` and AWS creds; the env-guard refuses
+  any table name without `preview`/`test`/`dev`.
+- `frontend/proxy.ts` is the Next.js middleware (named `proxy` for Next 16+); it handles
+  video-access cookies *and* auth route protection.

--- a/.claude/skills/expert/references/verification.md
+++ b/.claude/skills/expert/references/verification.md
@@ -1,0 +1,65 @@
+# Verification — how features get tested/verified here
+
+The cheapest layer that can catch a problem should. Order, cheapest → most expensive.
+
+## The deterministic gate: `scripts/local-checks.sh`
+
+Run from repo root before opening a PR (the harness runs it automatically). `set -uo
+pipefail` (not `-e`) so all checks run and aggregate. In order:
+
+1. **Lint** (block) — `pnpm run lint` in `backend`, `frontend`, `e2e` (eslint).
+2. **Typecheck** (block) — `pnpm run typecheck` (`tsc --noEmit`) in all three.
+3. **Fast unit tests** (block) — `pnpm run test:unit` in `backend` + `frontend` only.
+4. **Skip-detection** (block) — fails if the branch diff ADDS `.skip`/`.only`/`xit`/etc.
+5. **Custom invariant lints** (block) — every `scripts/lints/*.sh` (see `invariants.md`).
+6. **AGENTS.md freshness** (advisory/warn-only for now — see `invariants.md`).
+
+`./scripts/local-checks.sh fix` runs `eslint --fix` across the workspaces.
+Integration + e2e are deliberately NOT in this gate (too slow / need real infra).
+
+## Backend tests (`backend/jest.config.js` — two projects)
+
+- **unit** (`pnpm test:unit`): `**/__tests__/**/*.test.ts`, `node` env, ts-jest ESM,
+  **AWS mocked** via `aws-sdk-client-mock`. 80% coverage threshold; `collectCoverageFrom`
+  excludes `*.types.ts`/`*.repository.ts`/`*.interface.ts`. This is the suite the gate runs.
+- **integration** (`pnpm test:integration`): `**/__integration__/**/*.integration.test.ts`,
+  **hits REAL preview DynamoDB**. `src/__integration__/setup.ts` loads `backend/.env.integration`
+  (create from `.env.integration.example`) and runs `validateTestEnvironment()` —
+  a safety guard that **refuses any table name not containing `preview`/`test`/`dev`**.
+  Needs AWS creds. `--runInBand`, 30s timeout.
+
+## Frontend tests (`frontend/jest.config.js` — two projects)
+
+- **unit** (`pnpm test:unit`): jsdom, `@swc/jest`, tests in `__tests__/`. `jest.setup.js`
+  mocks `next-auth`, `next/navigation`, the `app/actions/auth` module, analytics.
+- **integration** (`pnpm test:integration`): **MSW** (`msw/node`) mocks the backend at
+  the network layer (`app/actions/__integration__/{setup,handlers}.ts`); covers full
+  client flows (dashboard, course, auto-resume, upsell) against the mocked API.
+  `jest.polyfills.js` provides the MSW v2 + undici fetch polyfills.
+
+## E2E (`e2e/`, Playwright)
+
+- `api` project: hits `API_URL` with `x-api-key`. `ui` project: drives `BASE_URL` in
+  Chrome, asserting rendering (it does NOT complete a real Google sign-in / paid enroll).
+- Runs against a **deployed Vercel preview** (the `webServer` block is disabled), with
+  `x-vercel-protection-bypass` from `VERCEL_AUTOMATION_BYPASS_SECRET`.
+
+## Running the app locally + reading signals
+
+- Background dev per workspace: `pnpm run dev:bg` (→ `nohup pnpm dev`), `dev:stop`,
+  `dev:logs` (`cat .local-dev.log`). Backend :8080, frontend :3000.
+- Deploy a preview + tail logs: `scripts/deploy-preview-{backend,frontend}.sh`, then
+  `scripts/start-{sam,vercel}-logs.sh` → read `scripts/.{sam,vercel}-logs.log` → act →
+  `stop-*-logs.sh`. (`scripts/README.md` documents the agent workflow.)
+
+## CI / hooks status
+
+There is **no test/build CI and no git hooks**. The only GitHub Actions workflow is
+`.github/workflows/claude-review.yml` — the one-way Claude PR reviewer (per `REVIEW.md`).
+So `local-checks.sh` + the PRD runner carry the deterministic weight before merge.
+
+## What "done" means
+
+A change is done when `./prds/<feature>/run-prd-test.sh` exits 0 (the runnable
+definition of done) **and** `local-checks.sh` passes. Heavier layers (integration,
+e2e, deploy) are run deliberately, not on every gate.

--- a/scripts/lints/frontend-no-backend-import.sh
+++ b/scripts/lints/frontend-no-backend-import.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# frontend-no-backend-import.sh — package-boundary invariant.
+#
+# INVARIANT: no file under frontend/ imports from backend/ (the two are separate
+# deployables — Vercel vs AWS Lambda — and their ONLY contract is the HTTP API).
+# Verified 0 violations at bootstrap.
+#
+# WHY: reaching into backend/ source from the frontend couples two independently
+# deployed packages, drags server-only/Node code into the client bundle, and
+# bypasses the HTTP API contract (auth, validation). Talk to the backend over HTTP.
+# Exit 0 = clean. Exit 1 = a violation with a remediation message.
+
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Match imports whose specifier resolves into the sibling backend/ package.
+hits="$(grep -rnE "from ['\"]([./]*/)*backend/|require\(['\"]([./]*/)*backend/" "$ROOT/frontend" \
+          --include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx' \
+          --exclude-dir=node_modules --exclude-dir=.next --exclude-dir=coverage 2>/dev/null || true)"
+
+if [[ -n "$hits" ]]; then
+  echo "❌ frontend-no-backend-import: frontend/ imports from backend/." >&2
+  echo "$hits" | sed 's/^/   /' >&2
+  cat >&2 <<'EOF'
+   WHY: frontend (Vercel) and backend (AWS Lambda) are separate deployables; their
+        only contract is the HTTP API. A source import couples them and can pull
+        server-only code into the client bundle.
+   FIX: call the backend over HTTP instead (frontend/lib/data/* server fetchers,
+        frontend/app/actions/* server actions, or the BFF route handlers in
+        frontend/app/api/*). Share types by duplicating the shape, not importing it.
+   Don't silence with a path alias — that hides the same cross-package edge.
+EOF
+  exit 1
+fi
+echo "frontend-no-backend-import: OK"

--- a/scripts/lints/no-console-backend.sh
+++ b/scripts/lints/no-console-backend.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# no-console-backend.sh — structured-logging invariant (backend).
+#
+# INVARIANT: backend application code (backend/src, excluding tests) never calls
+# console.*; all logging goes through createLogger() from backend/src/lib/logger.ts
+# (wraps @aws-lambda-powertools/logger). Verified 0 violations at bootstrap.
+#
+# WHY: this backend runs in AWS Lambda; CloudWatch + the Powertools logger consume
+# STRUCTURED JSON logs with a service name and request context. A bare console.*
+# emits unstructured output that breaks log queries and metric correlation.
+# Exit 0 = clean. Exit 1 = a violation with a remediation message.
+
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# App code only: exclude tests/integration helpers, which legitimately use console.
+hits="$(grep -rnE 'console\.(log|error|warn|info|debug)' "$ROOT/backend/src" \
+          --include='*.ts' --include='*.js' --exclude-dir=node_modules 2>/dev/null \
+        | grep -vE '\.test\.|/__tests__/|/__integration__/' || true)"
+
+if [[ -n "$hits" ]]; then
+  echo "❌ no-console-backend: console.* in backend app code — use the structured logger." >&2
+  echo "$hits" | sed 's/^/   /' >&2
+  cat >&2 <<'EOF'
+   WHY: Lambda/CloudWatch consume structured JSON logs; console.* is unstructured
+        and breaks log queries + metric correlation.
+   FIX: const logger = createLogger('<ModuleName>')  (from backend/src/lib/logger.ts),
+        then logger.info/.error(msg, { ...context }). Emit metrics via createMetrics().
+   Don't silence with an eslint-disable — the log still ships unstructured.
+EOF
+  exit 1
+fi
+echo "no-console-backend: OK"

--- a/scripts/lints/server-actions-use-server.sh
+++ b/scripts/lints/server-actions-use-server.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# server-actions-use-server.sh — server-action safety invariant.
+#
+# INVARIANT: every module in frontend/app/actions/*.ts begins with the 'use server'
+# directive. Verified 0 violations at bootstrap (auth, enrollments, feedback,
+# meetups, progress, students).
+#
+# WHY: these modules hold server-only logic and reach the backend with the Cognito
+# ID token sourced server-side. Without the directive at the top of the file, the
+# bundler may pull the code (and its secret handling) into the CLIENT bundle — a
+# real data-leak / privilege boundary failure, not a style nit.
+# Exit 0 = clean. Exit 1 = a violation with a remediation message.
+
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DIR="$ROOT/frontend/app/actions"
+
+[[ -d "$DIR" ]] || { echo "server-actions-use-server: OK (no actions dir)"; exit 0; }
+
+bad=()
+for f in "$DIR"/*.ts; do
+  [[ -e "$f" ]] || continue
+  # First non-empty line must be a "use server" directive (single or double quotes).
+  first="$(grep -m1 -vE '^[[:space:]]*$' "$f" | tr -d '[:space:]')"
+  case "$first" in
+    "'useserver';"|'"useserver";'|"'useserver'"|'"useserver"') : ;;
+    *) bad+=("$f") ;;
+  esac
+done
+
+if (( ${#bad[@]} )); then
+  echo "❌ server-actions-use-server: action module(s) missing the 'use server' directive:" >&2
+  printf '   %s\n' "${bad[@]}" >&2
+  cat >&2 <<'EOF'
+   WHY: without 'use server' at the top of the file, the bundler can pull this
+        server-only code (and its ID-token handling) into the CLIENT bundle — a
+        privilege/secret boundary failure, not a style nit.
+   FIX: make the FIRST line of the file exactly:  'use server'
+   Don't move the logic into a component to dodge this — keep mutations in
+        frontend/app/actions/* with the directive.
+EOF
+  exit 1
+fi
+echo "server-actions-use-server: OK"


### PR DESCRIPTION
## /learn --rebuild — Expert bootstrap

Seeds the project's long-term **memory** from a full scan of committed code on `main`. This is the memory PR you review and merge (the harness never auto-merges memory).

### What's in here
**Expert** — `.claude/skills/expert/` (lazy memory, pulled on demand):
- `architecture.md` — system shape, backend feature-slice layering, single-table DynamoDB, two-scheme Cognito auth, event-driven onboarding, frontend's 4 backend-access modes
- `core-files.md` — key files & their roles across backend / frontend / e2e
- `verification.md` — the `local-checks.sh` gate + jest unit/integration + Playwright + local-dev/signal scripts; "done" = `run-prd-test.sh` exit 0
- `patterns.md` — soft DO/DON'T (judgment)
- `invariants.md` — hard rules (mechanical)
- `procedural.md` — how to add a backend / frontend feature here
- `SKILL.md` + `changelog.md`

**Invariants promoted to enforced lints** (each a 1-line grep, structural/security, **0 violations vs `main`**, auto-run by `local-checks.sh §5`):
- `no-console-backend.sh` — structured logging in Lambda
- `frontend-no-backend-import.sh` — package boundary
- `server-actions-use-server.sh` — `'use server'` / client-bundle safety
- (`no-frontend-db.sh` already existed from `/harness-init`)

**6 further invariants recorded as prose** in `invariants.md` with check commands (ES-modules-only, DynamoDB-only-via-repository, backend `.js` import extension, no-`as any`-in-backend, client-only-`NEXT_PUBLIC_*` env, all-routers-registered-in-`app.ts`) — promote to lints on recurrence or by your call.

### How to review
- The shards are **memory, not code** — check they match your mental model of the system; correct anything that's wrong or overfit (it's the ground truth every future agent reads).
- Each promoted lint passed against `main` before commit; drop any you don't want enforced.
- `AGENTS.md` is unchanged: its Expert pointer now resolves; the freshness lint stays **advisory** because `check-agents-md.sh` false-positives on slash-command tokens and `<f>`-scoped filenames in the canonical skill-chain table.

### Consensus
4 parallel codebase analyzers (backend / frontend / verification / invariants) independently confirmed each rule with a 0-violation count; that agreement + the must-pass-`main` lint gate is the consensus for this from-scratch seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)